### PR TITLE
Add support for SMTP email server

### DIFF
--- a/config/prod.exs
+++ b/config/prod.exs
@@ -79,3 +79,4 @@ config :tmate, Tmate.Mailer,
   adapter: Bamboo.MailgunAdapter,
   api_key: System.get_env("MAILGUN_API_KEY"),
   domain: System.get_env("MAILGUN_DOMAIN")
+  from: System.get_env("EMAIL_FROM", "tmate <support@tmate.io>")

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -75,8 +75,20 @@ config :tmate, Tmate.Scheduler,
     {"*/1 * * * *", {Tmate.SessionCleaner, :prune_sessions, []}},
   ]
 
+email_adapter_opts = case (System.get_env("EMAIL_ADAPTER", "mailgun") |> String.downcase) do
+  "smtp" -> [
+    adapter: Bamboo.SMTPAdapter,
+    server: System.get_env("SMTP_HOST"),
+    port: System.get_env("SMTP_PORT"),
+    hostname: System.get_env("SMTP_DOMAIN")]
+  "mailgun" -> [
+    adapter: Bamboo.MailgunAdapter,
+    api_key: System.get_env("MAILGUN_API_KEY"),
+    domain: System.get_env("MAILGUN_DOMAIN")]
+  other -> raise "Unknown email handler: '#{other}'"
+end
+
 config :tmate, Tmate.Mailer,
-  adapter: Bamboo.MailgunAdapter,
-  api_key: System.get_env("MAILGUN_API_KEY"),
-  domain: System.get_env("MAILGUN_DOMAIN")
+  Keyword.merge(email_adapter_opts,
   from: System.get_env("EMAIL_FROM", "tmate <support@tmate.io>")
+)

--- a/lib/tmate_web/emails/email.ex
+++ b/lib/tmate_web/emails/email.ex
@@ -12,7 +12,7 @@ defmodule Tmate.Email do
 
   defp base_email do
     new_email()
-    |> from("tmate <support@tmate.io>")
+    |> from(Application.fetch_env!(:tmate, Tmate.Mailer)[:from])
     |> put_html_layout({TmateWeb.LayoutView, "email.html"})
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -54,6 +54,7 @@ defmodule Tmate.MixProject do
       {:timex, "~> 3.0"},
       {:httpoison, ">= 0.0.0"},
       {:bamboo, "~> 1.3"},
+      {:bamboo_smtp, "~> 3.0.0"},
     ]
   end
 


### PR DESCRIPTION
Introduce environment variable EMAIL_ADAPTER to choose the Bamboo
adpater to send email with. Current choices are:
* mailgun (default)
* smtp

An error is raised for any other value.
The value is case insensitive.

Each adapter requires its own environment variable set:
* mailgun:
  - MAILGUN_API_KEY
  - MAILGUN_DOMAINE
* smtp:
  - SMTP_HOST
  - SMTP_PORT
  - SMTP_DOMAIN

Also add EMAIL_FROM variable to set the From; address. Defaults to the previously hard coded address: "tmate &lt;support@tmate.io&gt;".

This patch doesn't break existing configurations: the adaptor defaults to mailgun.